### PR TITLE
turnip_formatter gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.bundle
 /vendor/bundle
+/tmp

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 -r turnip/rspec
+-f d
+--profile

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem 'representable', '2.3.0'
   gem 'selenium-webdriver'
   gem 'capybara'
+  gem 'turnip_formatter'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     byebug (10.0.2)
@@ -15,12 +20,16 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     coderay (1.1.2)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     ffi (1.9.25)
     gherkin (5.1.0)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
+    minitest (5.11.3)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     poltergeist (1.18.1)
@@ -60,9 +69,16 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
     test-queue (0.2.13)
+    thread_safe (0.3.6)
     turnip (3.1.0)
       gherkin (~> 5.0)
       rspec (>= 3.0, < 4.0)
+    turnip_formatter (0.7.1)
+      activesupport (>= 4.2.7, < 6.0)
+      rspec (>= 3.3, < 4.0)
+      turnip (~> 3.1.0)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     uber (0.0.15)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
@@ -84,6 +100,7 @@ DEPENDENCIES
   selenium-webdriver
   test-queue (< 0.3.0)
   turnip
+  turnip_formatter
 
 BUNDLED WITH
    1.16.1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,8 @@ pipeline {
           set -xe
           xvfb-run bundle exec rspec spec/features/*.feature
         '''
+        // Save tmp/turnip_formatter/report.html as artifact
+        archiveArtifacts allowEmptyArchive: true, artifacts: "tmp/turnip_formatter/report.html"
         // Cleanup workspace
         cleanWs()
       }

--- a/README.md
+++ b/README.md
@@ -4,4 +4,9 @@
 bundle exec rspec spec/features/*.feature
 ```
 
+parallel execution:
+
+```shell
+bundle exec ./exec/rspec-queue.rb spec/featureas/*.feature
+```
 

--- a/exec/rspec-queue.rb
+++ b/exec/rspec-queue.rb
@@ -1,0 +1,18 @@
+#! /usr/bin/env ruby
+
+require 'test_queue'
+require 'test_queue/runner/rspec'
+require 'turnip_formatter'
+
+class MyAppTestRunner < TestQueue::Runner::RSpec
+  def after_fork(num)
+    if use_turnip_formatter?
+      ::RSpec.configure do |config|
+        config.add_formatter ::RSpecTurnipFormatter, "tmp/turnip_formatter/report-#{num}.html"
+      end
+    end
+  end
+end
+
+MyAppTestRunner.new.execute
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,4 +7,15 @@ require 'capybara/poltergeist'
 require 'turnip'
 require 'turnip/capybara'
 require 'selenium-webdriver'
+require 'turnip_formatter'
+
+def use_turnip_formatter?
+  ENV['DISABLE_TURNIP_FORMATTER'] !~ /\A(1|on|true|yes)\z/i
+end
+
+RSpec.configure do |config|
+  if use_turnip_formatter?
+    config.add_formatter ::RSpecTurnipFormatter, 'tmp/turnip_formatter/report.html'
+  end
+end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,4 @@ require 'capybara/poltergeist'
 require 'turnip'
 require 'turnip/capybara'
 require 'selenium-webdriver'
-require "test_queue"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,12 @@ def use_turnip_formatter?
   ENV['DISABLE_TURNIP_FORMATTER'] !~ /\A(1|on|true|yes)\z/i
 end
 
+def rspec_queue?
+  defined?(::TestQueue::Runner::RSpec)
+end
+
 RSpec.configure do |config|
-  if use_turnip_formatter?
+  if !rspec_queue? && use_turnip_formatter?
     config.add_formatter ::RSpecTurnipFormatter, 'tmp/turnip_formatter/report.html'
   end
 end


### PR DESCRIPTION
`bundle exec rspec spec/features/*.feature` will generate tmp/turnip_formatter/report.html:

![image](https://user-images.githubusercontent.com/162862/42023233-516035f0-7afa-11e8-868c-d7b9e7779c58.png)

And `bundle exec rspec-queue spec/features/*.feature` will generate
tmp/turnip_formatter/{report-1.html,report-2.html,...}.
