### PR TITLE
turnip が作る rspec の example の description が長すぎるのを短くします

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'capybara'
   gem 'turnip_formatter'
+  gem 'activesupport'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   capybara
   poltergeist
   pry-byebug

--- a/lib/monkey_patches/turnip_ext.rb
+++ b/lib/monkey_patches/turnip_ext.rb
@@ -1,0 +1,52 @@
+## Turnip::RSpec.run_feature (https://github.com/jnicklas/turnip/blob/v3.1.0/lib/turnip/rspec.rb#L79-L102)
+## をモンキーパッチして rspec の example の description を activesupport の String#truncate_words で短くします
+
+require 'turnip/rspec'
+require 'active_support/core_ext/string/filters'
+
+expected_turnip_version = '3.1.0'
+if Turnip::VERSION != expected_turnip_version
+  raise "#{__FILE__} は turnip #{expected_turnip_version} 向けに書かれています"
+end
+
+module TurnipMonkeyPatch
+  module ShortenExampleDescription
+    private
+
+    def run_feature(context, feature, filename)
+      background_steps = feature.backgrounds.map(&:steps).flatten
+
+      context.before do
+        background_steps.each do |step|
+          run_step(filename, step)
+        end
+      end
+
+      feature.scenarios.each do |scenario|
+        step_names = (background_steps + scenario.steps).map(&:to_s)
+        description = step_names.join(' -> ')
+
+        description = description.truncate_words 5, omission: " ...(snip)..."
+
+        context.describe scenario.name, scenario.metadata_hash do
+          instance_eval <<-EOS, filename, scenario.line
+              it description do
+                scenario.steps.each do |step|
+                  run_step(filename, step)
+                end
+              end
+          EOS
+        end
+      end
+    end
+  end
+end
+
+module Turnip
+  module RSpec
+    class << self
+      prepend TurnipMonkeyPatch::ShortenExampleDescription
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,11 @@ require 'turnip'
 require 'turnip/capybara'
 require 'selenium-webdriver'
 require 'turnip_formatter'
+require 'pry'
+require 'pathname'
+
+$LOAD_PATH.unshift "#{__dir__}/../lib"
+require 'monkey_patches/turnip_ext'
 
 def use_turnip_formatter?
   ENV['DISABLE_TURNIP_FORMATTER'] !~ /\A(1|on|true|yes)\z/i


### PR DESCRIPTION
[Turnip::RSpec の run_feature](https://github.com/jnicklas/turnip/blob/v3.1.0/lib/turnip/rspec.rb#L79-L102) をモンキーパッチしてますが、
実質の変更はこれだけです。
https://github.com/TakeruUshio/selenium_test/blob/436dbd4f8336bc15790ddb97e6f5bf3fbc560c72/lib/monkey_patches/turnip_ext.rb#L29


before:

![image](https://user-images.githubusercontent.com/162862/42985973-a9217b60-8c2e-11e8-9f65-ce20ae66ab84.png)


after:

![image](https://user-images.githubusercontent.com/162862/42985981-b58d72be-8c2e-11e8-9883-c2dff4655e67.png)

