### PR TITLE
step 呼び出しの前後にログ出力

### DIFF
--- a/lib/monkey_patches/turnip_ext.rb
+++ b/lib/monkey_patches/turnip_ext.rb
@@ -1,1 +1,2 @@
 require_relative 'turnip_ext/shorten_example_description'
+require_relative 'turnip_ext/step_call_with_logger'

--- a/lib/monkey_patches/turnip_ext/step_call_with_logger.rb
+++ b/lib/monkey_patches/turnip_ext/step_call_with_logger.rb
@@ -1,0 +1,70 @@
+## Turnip::Execute#step (https://github.com/jnicklas/turnip/blob/v3.1.0/lib/turnip/execute.rb)
+## をラップして step 呼び出しの前後にログ出力します
+
+require 'logger'
+require 'turnip/execute'
+require 'turnip/version'
+
+expected_turnip_version = '3.1.0'
+if Turnip::VERSION != expected_turnip_version
+  raise "#{__FILE__} は turnip #{expected_turnip_version} 向けに書かれています"
+end
+
+module MonkeyPatches
+  module TurnipExt
+    module StepCallWithLogger
+      class StepCounter
+        def initialize
+          @current_depth = 0
+          @count = Hash.new(0)
+        end
+
+        def count(&block)
+          @current_depth += 1
+          @count[@current_depth] += 1
+          step_count = @count.sort_by{|k,v| k}.select{|k,v| k <= @current_depth }.map{|k,v| v }.join("-")
+          begin
+            block.call step_count
+          ensure
+            @count.delete(@current_depth+1) if @count.has_key?(@current_depth+1)
+            @current_depth -= 1
+          end
+        end
+      end
+
+      def step_with_hook(step_or_description, *extra_args)
+        @logger ||= defined?(logger) ? logger : Logger.new($stdout).tap{|o| o.level = :debug }
+        @counter ||= StepCounter.new
+
+        step_name = step_or_description.respond_to?(:description) ? step_or_description.description : step_or_description
+        t1 = Time.now
+
+        @counter.count do |step_count|
+          @logger.debug "[#{step_count}] Starting step #{step_name}"
+          begin
+            r = step_without_hook(step_or_description, *extra_args)
+            t2 = Time.now
+            @logger.info "[#{step_count}] Finished step #{step_name} (#{"%.3f" % [t2-t1]} sec)"
+            r
+          rescue StandardError, ::RSpec::Expectations::ExpectationNotMetError => e
+            t2 = Time.now
+            @logger.error "[#{step_count}] Failed step #{step_name} (#{"%.3f" % [t2-t1]} sec)"
+            raise e
+          end
+        end
+      end
+
+      def self.included(mod)
+        mod.alias_method :step_without_hook, :step
+        mod.alias_method :step, :step_with_hook
+      end
+    end
+  end
+end
+
+module Turnip
+  module Execute
+    include MonkeyPatches::TurnipExt::StepCallWithLogger
+  end
+end
+

--- a/lib/monkey_patches/turnip_ext/step_call_with_logger.rb
+++ b/lib/monkey_patches/turnip_ext/step_call_with_logger.rb
@@ -63,7 +63,7 @@ module MonkeyPatches
           r
         rescue StandardError, ::RSpec::Expectations::ExpectationNotMetError => e
           t2 = Time.now
-          @logger.send(log_level_map[:failed], "[#{step_count}] Failed step #{step_name} (#{"%.3f" % [t2-t1]} sec)")
+          @logger.send(log_level_map[:failed], "[#{step_count}] Failed step #{step_name} (#{"%.3f" % [t2-t1]} sec, exception: #{e.class})")
           raise e
         ensure
           @current = parent

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,14 @@ require 'selenium-webdriver'
 require 'turnip_formatter'
 require 'pry'
 require 'pathname'
+require 'logger'
 
 $LOAD_PATH.unshift "#{__dir__}/../lib"
 require 'monkey_patches/turnip_ext'
+
+def logger
+  @logger ||= Logger.new($stdout, level: :info)
+end
 
 def use_turnip_formatter?
   ENV['DISABLE_TURNIP_FORMATTER'] !~ /\A(1|on|true|yes)\z/i


### PR DESCRIPTION
```console
$ bundle exec rspec spec/features/*.feature

サンプル
  サンプル
I, [2018-09-18T08:00:39.992601 #5147]  INFO -- : [1] Finished step Seleniumでブラウザを使用する (3.217 sec)
I, [2018-09-18T08:00:46.941572 #5147]  INFO -- : [2] Finished step 'https://travis-ci.org' にアクセスする (6.949 sec)
I, [2018-09-18T08:00:47.726626 #5147]  INFO -- : [3] Finished step 'Sign Up' ボタンが表示されていること (0.785 sec)
I, [2018-09-18T08:00:48.678553 #5147]  INFO -- : [4] Finished step Seleniumのブラウザを閉じる (0.952 sec)
    もしSeleniumでブラウザを使用する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...

サンプル
  サンプル
I, [2018-09-18T08:00:51.331378 #5147]  INFO -- : [1] Finished step Seleniumでブラウザを使用する (2.650 sec)
I, [2018-09-18T08:00:58.511300 #5147]  INFO -- : [2] Finished step 'https://travis-ci.org' にアクセスする (7.180 sec)
I, [2018-09-18T08:00:59.193657 #5147]  INFO -- : [3] Finished step 'Sign Up' ボタンが表示されていること (0.682 sec)
I, [2018-09-18T08:01:00.000037 #5147]  INFO -- : [4] Finished step Seleniumのブラウザを閉じる (0.806 sec)
    もしSeleniumでブラウザを使用する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...

Top 2 slowest examples (23.22 seconds, 100.0% of total time):
  サンプル サンプル もしSeleniumでブラウザを使用する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
11.9seconds ./spec/features/sample_2.feature:5
  サンプル サンプル もしSeleniumでブラウザを使用する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
11.32seconds ./spec/features/sample.feature:5

Top 2 slowest example groups:
  サンプル
11.91seconds average (11.91 seconds / 1 example) ./spec/features/sample_2.feature:4
  サンプル
11.32seconds average (11.32 seconds / 1 example) ./spec/features/sample.feature:4

Finished in 23.23 seconds (files took 1.17 seconds to load)
2 examples, 0 failures
```