### PR TITLE
Scenarios are executed in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Run test
-        run: bundle exec rspec spec/features/ || bundle exec rspec spec/features/ --only-failures
+        run: bundle exec parallel_rspec -n 2 --type turnip spec/features/ || bundle exec rspec spec/features/ --only-failures
         env:
           USE_HEADLESS: 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Run test
-        run: bundle exec parallel_rspec -n 2 --type turnip spec/features/ || bundle exec rspec spec/features/ --only-failures
+        run: bundle exec parallel_rspec -n 2 --type turnip spec/features/ || bundle exec parallel_rspec -n 2 --type turnip -- --only-failures -- spec/features/
         env:
           USE_HEADLESS: 'true'
-

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'turnip_formatter'
   gem 'activesupport'
+  gem 'parallel_tests'
 end
 
 group :test, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem 'turnip_formatter'
   gem 'activesupport'
   gem 'parallel_tests'
+  gem 'turnip-parallel_tests'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,9 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
     minitest (5.13.0)
+    parallel (1.19.1)
+    parallel_tests (2.31.0)
+      parallel
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -68,6 +71,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  parallel_tests
   pry-byebug
   pry-doc
   representable (= 3.0.4)
@@ -77,4 +81,4 @@ DEPENDENCIES
   turnip_formatter
 
 BUNDLED WITH
-   2.1.1
+   2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
     turnip (3.1.0)
       gherkin (~> 5.0)
       rspec (>= 3.0, < 4.0)
+    turnip-parallel_tests (0.0.1)
+      parallel_tests
     turnip_formatter (0.7.2)
       activesupport (>= 4.2.7, < 7.0)
       rspec (>= 3.3, < 4.0)
@@ -78,6 +80,7 @@ DEPENDENCIES
   rspec (= 3.9.0)
   selenium-webdriver
   turnip
+  turnip-parallel_tests
   turnip_formatter
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ Run selenium4 feature only `@selenium4` tag scenario:
 BUNDLE_GEMFILE=gemfiles/selenium_4.gemfile bundle exec rspec spec/features/sample_use_selenium3_or_seleninum4.feature
 ```
 
+Run parallel
+
+```shell
+bundle exec parallel_rspec -n 2 --type turnip spec/features/
+```
+

--- a/gemfiles/selenium_3.gemfile
+++ b/gemfiles/selenium_3.gemfile
@@ -8,6 +8,8 @@ group :test do
   gem 'selenium-webdriver'
   gem 'turnip_formatter'
   gem 'activesupport'
+  gem 'parallel_tests'
+  gem 'turnip-parallel_tests'
 end
 
 group :test, :development do

--- a/gemfiles/selenium_3.gemfile.lock
+++ b/gemfiles/selenium_3.gemfile.lock
@@ -19,6 +19,9 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
     minitest (5.11.3)
+    parallel (1.19.1)
+    parallel_tests (2.31.0)
+      parallel
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -54,6 +57,8 @@ GEM
     turnip (3.1.0)
       gherkin (~> 5.0)
       rspec (>= 3.0, < 4.0)
+    turnip-parallel_tests (0.0.1)
+      parallel_tests
     turnip_formatter (0.7.1)
       activesupport (>= 4.2.7, < 6.0)
       rspec (>= 3.3, < 4.0)
@@ -68,13 +73,15 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  parallel_tests
   pry-byebug
   pry-doc
   representable (= 3.0.4)
   rspec (= 3.9.0)
   selenium-webdriver
   turnip
+  turnip-parallel_tests
   turnip_formatter
 
 BUNDLED WITH
-   2.1.1
+   2.1.2

--- a/gemfiles/selenium_4.gemfile
+++ b/gemfiles/selenium_4.gemfile
@@ -8,6 +8,8 @@ group :test do
   gem 'selenium-webdriver', '4.0.0.alpha3'
   gem 'turnip_formatter'
   gem 'activesupport'
+  gem 'parallel_tests'
+  gem 'turnip-parallel_tests'
 end
 
 group :test, :development do

--- a/gemfiles/selenium_4.gemfile.lock
+++ b/gemfiles/selenium_4.gemfile.lock
@@ -19,6 +19,9 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
     minitest (5.11.3)
+    parallel (1.19.1)
+    parallel_tests (2.31.0)
+      parallel
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -54,6 +57,8 @@ GEM
     turnip (3.1.0)
       gherkin (~> 5.0)
       rspec (>= 3.0, < 4.0)
+    turnip-parallel_tests (0.0.1)
+      parallel_tests
     turnip_formatter (0.7.1)
       activesupport (>= 4.2.7, < 6.0)
       rspec (>= 3.3, < 4.0)
@@ -68,13 +73,15 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  parallel_tests
   pry-byebug
   pry-doc
   representable (= 3.0.4)
   rspec (= 3.9.0)
   selenium-webdriver (= 4.0.0.alpha3)
   turnip
+  turnip-parallel_tests
   turnip_formatter
 
 BUNDLED WITH
-   2.1.1
+   2.1.2


### PR DESCRIPTION
* Scenarios are executed in parallel.


Operation check (only retry)

<details>
<summary>Operation log</summary>

```shell
$ bundle exec parallel_rspec -n 2 --type turnip spec/features/
2 processes for 7 turnips, ~ 3 turnips per process

サンプル
  サンプル

サンプル
  サンプル
/Users/ta-ushio/work_space/selenium_test/vender/bundle/ruby/2.7.0/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/common/driver.rb:54: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/ta-ushio/work_space/selenium_test/vender/bundle/ruby/2.7.0/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/firefox/driver.rb:31: warning: The called method `new' is defined here
/Users/ta-ushio/work_space/selenium_test/vender/bundle/ruby/2.7.0/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/common/driver.rb:54: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/ta-ushio/work_space/selenium_test/vender/bundle/ruby/2.7.0/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/firefox/driver.rb:31: warning: The called method `new' is defined here
I, [2020-02-19T14:40:58.073703 #38922]  INFO -- : [1] Finished step ブラウザを起動する (5.506 sec)
I, [2020-02-19T14:40:58.646104 #38921]  INFO -- : [1] Finished step ブラウザを起動する (6.080 sec)
I, [2020-02-19T14:41:03.165602 #38922]  INFO -- : [2] Finished step 'https://travis-ci.org' にアクセスする (5.091 sec)
I, [2020-02-19T14:41:03.617490 #38922]  INFO -- : [3] Finished step 'Sign Up' ボタンが表示されていること (0.452 sec)
I, [2020-02-19T14:41:04.590001 #38921]  INFO -- : [2] Finished step 'https://travis-ci.org' にアクセスする (5.944 sec)
I, [2020-02-19T14:41:04.789762 #38921]  INFO -- : [3] Finished step 'Sign Up' ボタンが表示されていること (0.200 sec)
I, [2020-02-19T14:41:07.842362 #38922]  INFO -- : [4] Finished step Seleniumのブラウザを閉じる (4.225 sec)
    もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...

サンプル
  リトライすると成功する
I, [2020-02-19T14:41:07.846799 #38922]  INFO -- : [1] Finished step 前回のこのシナリオの結果が failed である (0.003 sec)
    もし前回のこのシナリオの結果が failed である

サンプル
  サンプル
I, [2020-02-19T14:41:08.921936 #38921]  INFO -- : [4] Finished step Seleniumのブラウザを閉じる (4.132 sec)
    もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...

サンプル
  use browser firefox
I, [2020-02-19T14:41:10.146300 #38922]  INFO -- : [1] Finished step ブラウザを起動する (2.299 sec)
I, [2020-02-19T14:41:16.124220 #38921]  INFO -- : [1] Finished step ブラウザを起動する (7.201 sec)
I, [2020-02-19T14:41:16.126446 #38921]  INFO -- : [2] Finished step 起動したブラウザが firefox であること (0.002 sec)
I, [2020-02-19T14:41:16.797127 #38922]  INFO -- : [2] Finished step 'https://travis-ci.org' にアクセスする (6.651 sec)
I, [2020-02-19T14:41:16.937112 #38922]  INFO -- : [3] Finished step 'Sign Up' ボタンが表示されていること (0.139 sec)
I, [2020-02-19T14:41:17.352543 #38922]  INFO -- : [4] Finished step Seleniumのブラウザを閉じる (0.415 sec)
    もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...

サンプル
  use selenium3
I, [2020-02-19T14:41:20.872390 #38921]  INFO -- : [3] Finished step 'https://travis-ci.org' にアクセスする (4.746 sec)
I, [2020-02-19T14:41:21.072714 #38921]  INFO -- : [4] Finished step 'Sign Up' ボタンが表示されていること (0.200 sec)
I, [2020-02-19T14:41:23.177157 #38922]  INFO -- : [1] Finished step ブラウザを起動する (5.787 sec)
I, [2020-02-19T14:41:24.984857 #38921]  INFO -- : [5] Finished step Seleniumのブラウザを閉じる (3.912 sec)
    もしブラウザを起動する -> ならば起動したブラウザが firefox であること ...(snip)...
  use browser chrome
I, [2020-02-19T14:41:27.266627 #38921]  INFO -- : [1] Finished step ブラウザを起動する (2.280 sec)
I, [2020-02-19T14:41:27.267227 #38921]  INFO -- : [2] Finished step 起動したブラウザが chrome であること (0.000 sec)
I, [2020-02-19T14:41:31.357902 #38922]  INFO -- : [2] Finished step 'https://travis-ci.org' にアクセスする (8.181 sec)
I, [2020-02-19T14:41:31.566149 #38922]  INFO -- : [3] Finished step 'Sign Up' ボタンが表示されていること (0.208 sec)
I, [2020-02-19T14:41:32.067671 #38921]  INFO -- : [3] Finished step 'https://travis-ci.org' にアクセスする (4.800 sec)
I, [2020-02-19T14:41:32.134316 #38921]  INFO -- : [4] Finished step 'Sign Up' ボタンが表示されていること (0.066 sec)
I, [2020-02-19T14:41:32.487194 #38921]  INFO -- : [5] Finished step Seleniumのブラウザを閉じる (0.353 sec)
    もしブラウザを起動する -> ならば起動したブラウザが chrome であること ...(snip)...

sample
  Get chrome console log
I, [2020-02-19T14:41:34.502975 #38921]  INFO -- : [1] Finished step ブラウザを起動する (1.983 sec)
I, [2020-02-19T14:41:36.629799 #38921]  INFO -- : [2] Finished step 'https://www.yahoo.co.jp/' にアクセスする (2.126 sec)
I, [2020-02-19T14:41:36.632038 #38921]  INFO -- : Chrome Console Log [2020-02-19 14:41:36 +0900] [WARNING] : https://www.yahoo.co.jp/ - A cookie associated with a cross-site resource at http://yahoo.co.jp/ was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.
I, [2020-02-19T14:41:36.632081 #38921]  INFO -- : Chrome Console Log [2020-02-19 14:41:36 +0900] [WARNING] : https://www.yahoo.co.jp/ - A cookie associated with a cross-site resource at http://yimg.jp/ was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.
I, [2020-02-19T14:41:36.632105 #38921]  INFO -- : Chrome Console Log [2020-02-19 14:41:36 +0900] [WARNING] : https://www.yahoo.co.jp/ - A cookie associated with a cross-site resource at http://s.yimg.jp/ was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.
    もしブラウザを起動する -> かつ'https://www.yahoo.co.jp/' にアクセスする

Top 4 slowest examples (44.06 seconds, 100.0% of total time):
  サンプル サンプル もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
    16.36 seconds ./spec/features/sample.feature:6
  サンプル use browser firefox もしブラウザを起動する -> ならば起動したブラウザが firefox であること ...(snip)...
    16.06 seconds ./spec/features/sample_use_chrome_and_firefox.feature:6
  サンプル use browser chrome もしブラウザを起動する -> ならば起動したブラウザが chrome であること ...(snip)...
    7.53 seconds ./spec/features/sample_use_chrome_and_firefox.feature:14
  sample Get chrome console log もしブラウザを起動する -> かつ'https://www.yahoo.co.jp/' にアクセスする
    4.11 seconds ./spec/features/use_developer_tool_by_chrome.feature:6

Top 3 slowest example groups:
  サンプル
    16.36 seconds average (16.36 seconds / 1 example) ./spec/features/sample.feature:5
  サンプル
    11.8 seconds average (23.6 seconds / 2 examples) ./spec/features/sample_use_chrome_and_firefox.feature:4
  sample
    4.11 seconds average (4.11 seconds / 1 example) ./spec/features/use_developer_tool_by_chrome.feature:5

Finished in 44.07 seconds (files took 0.97204 seconds to load)
4 examples, 0 failures

I, [2020-02-19T14:41:37.330946 #38922]  INFO -- : [4] Finished step Seleniumのブラウザを閉じる (5.765 sec)
    もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
  use selenium4
    もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)... (PENDING: No reason given)

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) サンプル use selenium4 もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
     # No reason given
     # ./spec/features/sample_use_selenium3_or_seleninum4.feature:13


Top 5 slowest examples (44.76 seconds, 100.0% of total time):
  サンプル use selenium3 もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
    19.94 seconds ./spec/features/sample_use_selenium3_or_seleninum4.feature:6
  サンプル サンプル もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
    15.27 seconds ./spec/features/sample_2.feature:6
  サンプル サンプル もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
    9.54 seconds ./spec/features/sample_use_chrome.feature:6
  サンプル リトライすると成功する もし前回のこのシナリオの結果が failed である
    0.00307 seconds ./spec/features/sample_retry.feature:5
  サンプル use selenium4 もしブラウザを起動する -> もし'https://travis-ci.org' にアクセスする -> ...(snip)...
    0.00018 seconds ./spec/features/sample_use_selenium3_or_seleninum4.feature:13

Top 4 slowest example groups:
  サンプル
    15.28 seconds average (15.28 seconds / 1 example) ./spec/features/sample_2.feature:5
  サンプル
    9.97 seconds average (19.94 seconds / 2 examples) ./spec/features/sample_use_selenium3_or_seleninum4.feature:4
  サンプル
    9.54 seconds average (9.54 seconds / 1 example) ./spec/features/sample_use_chrome.feature:5
  サンプル
    0.00356 seconds average (0.00356 seconds / 1 example) ./spec/features/sample_retry.feature:4

Finished in 44.77 seconds (files took 0.9704 seconds to load)
5 examples, 0 failures, 1 pending


9 examples, 0 failures, 1 pending

Took 46 seconds
```

</details>
