### PR TITLE
Report split when run in parallel.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,8 +34,8 @@ end
 def turnip_formatter_output_filename(is_retry: false)
   d = 'tmp/turnip_formatter'
   f = 'report.html'
-  n = ENV['TEST_ENV_NUMBER']
-  unless n.nil?
+
+  if n = ENV['TEST_ENV_NUMBER']
     n = "1" if n.empty?
     f = File.basename(f, '.*') + "_#{n}" + File.extname(f)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,11 @@ end
 def turnip_formatter_output_filename(is_retry: false)
   d = 'tmp/turnip_formatter'
   f = 'report.html'
+  n = ENV['TEST_ENV_NUMBER']
+  unless n.nil?
+    n = "1" if n.empty?
+    f = File.basename(f, '.*') + "_#{n}" + File.extname(f)
+  end
   f = File.basename(f, '.*') + "_#{ENV['STAGE_NAME']}" + File.extname(f) if jenkins?
   f = File.basename(f, '.*') + '_retry' + File.extname(f) if is_retry
   File.join(d, f)


### PR DESCRIPTION
When running in parallel, the report output by turnip formatter was broken, so a report was output for each parallel execution.

