### PR TITLE
GitHub Actions ワークフローで set-output を使っていたステップを書き換え

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: setup matrix_id
         id: setup_matrix_id
-        run: echo '::set-output name=MATRIX_ID::'${{ matrix.ruby_version }}-$(basename ${{ matrix.gemfile }})
+        run: echo "MATRIX_ID=${{ matrix.ruby_version }}-$(basename ${{ matrix.gemfile }})" >> "$GITHUB_OUTPUT"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

closes #164